### PR TITLE
Update fsroot/var/lib/minecraft/web/include/tabs/plugins.php

### DIFF
--- a/fsroot/var/lib/minecraft/web/include/tabs/plugins.php
+++ b/fsroot/var/lib/minecraft/web/include/tabs/plugins.php
@@ -55,7 +55,7 @@ foreach ($ps as $p) {
 	 $version_lines[0]
 	 );
   for ($i=1; $i<sizeof($version_lines); $i++) {
-    $printf("<tr>%s</tr>\n", $version_lines[$i]);
+    printf("<tr>%s</tr>\n", $version_lines[$i]);
   }
 }
 echo "</table>\n";


### PR DESCRIPTION
Removed typo which was causing plugins tab to fail if there was more than one version of the plugin.
