### PR TITLE
Fixing lsof Warnings & Disabling lsof Reverse name Lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Don't need eclipse junk
+.project
+.settings

--- a/fsroot/var/lib/minecraft/minecraft_base.sh
+++ b/fsroot/var/lib/minecraft/minecraft_base.sh
@@ -59,7 +59,7 @@ function set_server_log() {
     if is_server_online; then
 	#look at which files the serhas has open
         PID=`cat $PATH_MINECRAFT_PID`
-	if [ "`lsof -p$PID |grep -P 'server/server.log$'`" != "" ]; then
+	if [ "`lsof -n -w -p$PID |grep -P 'server/server.log$'`" != "" ]; then
 	    SERVER_LOG=$PRE17;
 	else
 	    SERVER_LOG=$POST17;


### PR DESCRIPTION
Fixed warnings that display on the web FE like below when there are bad/old/etc mounts. 

"lsof: WARNING: can't stat() cifs file system"

Also improving lsof performance by disabling reverse DNS resolution for active connections. 
